### PR TITLE
hash namespace in azure blob container name

### DIFF
--- a/lib/Tvm.js
+++ b/lib/Tvm.js
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 const joi = require('@hapi/joi')
 const openwhisk = require('openwhisk')
 const logger = require('@adobe/aio-lib-core-logging')('@adobe/aio-tvm')
+const crypto = require('crypto')
 
 /**
  * @classdesc Abstract Tvm class
@@ -42,11 +43,15 @@ class Tvm {
    * @param  {number} status http status code
    * @returns {object} { body : { error: err }, statusCode: status }
    */
-  static errorResponse (err, status) {
+  static _errorResponse (err, status) {
     return {
       body: { error: err },
       statusCode: status
     }
+  }
+
+  static _hash (str) {
+    return crypto.createHash('sha256').update(str, 'binary').digest('hex')
   }
 
   /**
@@ -144,14 +149,14 @@ class Tvm {
       params.owAuth = params.__ow_headers && params.__ow_headers.authorization
       if (!(params.owAuth)) {
         logger.warn(`missing authorization header for request with namespace ${params.owNamespace}`)
-        return Tvm.errorResponse('missing authorization header', 401)
+        return Tvm._errorResponse('missing authorization header', 401)
       }
 
       // 2. validation
       const res = this._validateRequestParams(params)
       if (res.error) {
         logger.warn(`bad request: ${res.error.message}`)
-        return Tvm.errorResponse(res.error.message, 400)
+        return Tvm._errorResponse(res.error.message, 400)
       }
       // important - parse expiryDuration to int
       params.expirationDuration = parseInt(params.expirationDuration)
@@ -164,7 +169,7 @@ class Tvm {
         await this._validateNamespaceInWhitelist(params.owNamespace, params.whitelist)
       } catch (e) {
         logger.warn(`unauthorized request: ${e.message}`)
-        return Tvm.errorResponse('unauthorized request', 403)
+        return Tvm._errorResponse('unauthorized request', 403)
       }
 
       logger.info('request is authorized')
@@ -184,7 +189,7 @@ class Tvm {
       }
     } catch (e) {
       logger.error(e.message)
-      return Tvm.errorResponse('server error', 500)
+      return Tvm._errorResponse('server error', 500)
     }
   }
 }

--- a/lib/Tvm.js
+++ b/lib/Tvm.js
@@ -51,7 +51,7 @@ class Tvm {
   }
 
   static _hash (str) {
-    return crypto.createHash('sha256').update(str, 'binary').digest('hex')
+    return crypto.createHash('sha256').update(str, 'binary').digest('hex').slice(32)
   }
 
   /**

--- a/lib/impl/AzureBlobTvm.js
+++ b/lib/impl/AzureBlobTvm.js
@@ -12,7 +12,6 @@ governing permissions and limitations under the License.
 
 const { Tvm } = require('../Tvm')
 const azure = require('@azure/storage-blob')
-const joi = require('@hapi/joi')
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 async function _createContainerIfNotExists (container, aborter, options) {
@@ -37,8 +36,6 @@ class AzureBlobTvm extends Tvm {
     super()
     this._addToValidationSchema('azureStorageAccount')
     this._addToValidationSchema('azureStorageAccessKey')
-    // min chars for container name, make sure owNamespace has at least 3 chars
-    this._addToValidationSchema('owNamespace', joi.string().min(3).required())
   }
 
   /**
@@ -50,8 +47,8 @@ class AzureBlobTvm extends Tvm {
     const accountURL = `https://${params.azureStorageAccount}.blob.core.windows.net`
     const sharedKeyCredential = new azure.SharedKeyCredential(params.azureStorageAccount, params.azureStorageAccessKey)
 
-    // make container name work with azure restricted char set by making it hex
-    const containerName = Buffer.from(params.owNamespace, 'utf8').toString('hex')
+    // hash container name to remove restricted chars + hide namespace of public container
+    const containerName = Tvm._hash(params.owNamespace)
     const privateContainerName = containerName
     const publicContainerName = containerName + '-public'
 

--- a/test/unit/jest.setup.js
+++ b/test/unit/jest.setup.js
@@ -30,6 +30,7 @@ global.baseNoErrorParams = {
   owNamespace: 'fakeNS',
   __ow_headers: { authorization: 'fakeAuth' }
 }
+global.nsHash = 'b7bb8447341643f7366d4604cdf8117f'
 
 const openwhisk = require('openwhisk')
 jest.mock('openwhisk')

--- a/test/unit/lib/impl/AzureBlobTvm.test.js
+++ b/test/unit/lib/impl/AzureBlobTvm.test.js
@@ -58,7 +58,7 @@ describe('processRequest (Azure Cosmos)', () => {
     azure.generateBlobSASQueryParameters.mockReset()
 
     // defaults that work
-    azure.generateBlobSASQueryParameters.mockResolvedValue({ toString: () => fakeSas })
+    azure.generateBlobSASQueryParameters.mockReturnValue({ toString: () => fakeSas })
   })
 
   describe('param validation', () => {
@@ -71,8 +71,7 @@ describe('processRequest (Azure Cosmos)', () => {
     const expectTokenGenerated = async () => {
       const response = await tvm.processRequest(fakeParams)
 
-      // sha256
-      const containerName = require('crypto').createHash('sha256').update(global.baseNoErrorParams.owNamespace, 'binary').digest('hex')
+      const containerName = global.nsHash
 
       expect(response.statusCode).toEqual(200)
       expect(response.body).toEqual({

--- a/test/unit/lib/impl/AzureBlobTvm.test.js
+++ b/test/unit/lib/impl/AzureBlobTvm.test.js
@@ -62,7 +62,6 @@ describe('processRequest (Azure Cosmos)', () => {
   })
 
   describe('param validation', () => {
-    test('when owNamespace is smaller than 3 chars', async () => global.testParam(tvm, fakeParams, 'owNamespace', 'aa'))
     test('when owNamespace is missing', async () => global.testParam(tvm, fakeParams, 'owNamespace', undefined))
     test('when azureStorageAccount is missing', async () => global.testParam(tvm, fakeParams, 'azureStorageAccount', undefined))
     test('when azureStorageAccessKey is missing', async () => global.testParam(tvm, fakeParams, 'azureStorageAccessKey', undefined))
@@ -72,8 +71,8 @@ describe('processRequest (Azure Cosmos)', () => {
     const expectTokenGenerated = async () => {
       const response = await tvm.processRequest(fakeParams)
 
-      // todo remove duplicated implementation of partitionKey name creation
-      const containerName = Buffer.from(fakeParams.owNamespace, 'utf8').toString('hex')
+      // sha256
+      const containerName = require('crypto').createHash('sha256').update(global.baseNoErrorParams.owNamespace, 'binary').digest('hex')
 
       expect(response.statusCode).toEqual(200)
       expect(response.body).toEqual({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
use sha256 hash instead of hex  of namespace for containerName

the reason is that files exposed in public container have the container name visible in the URL, and we should hide the namespace in public urls
<!--- Describe your changes in detail -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
