### PR TITLE
Updated .gitignore for windows/mac users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ dist/
 .lib
 playground/
 coverage/
+
+# Directory Cache Files
+.DS_Store
+thumbs.db
+.vscode


### PR DESCRIPTION


## Description

`.DS_Store` is a MacOS directory cache file and `thumbs.db` is a windows directory cache file. Sometimes Mac/Windows users accidentally push these files which may interfere with other Mac/Windows users.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
