### PR TITLE
Fix for > 32 chars I/O Runtime namespaces and support < 64 chars

### DIFF
--- a/lib/Tvm.js
+++ b/lib/Tvm.js
@@ -32,7 +32,7 @@ class Tvm {
       approvedList: joi.string().required(),
       owApihost: joi.string().uri().required(),
       // those are user openwhisk credentials passed as request params
-      owNamespace: joi.string().required(),
+      owNamespace: joi.string().min(3).max(63).required(),
       // owAuth is redundant here as we already check it but it cannot hurt to check twice
       owAuth: joi.string().required()
     }

--- a/lib/impl/AwsS3Tvm.js
+++ b/lib/impl/AwsS3Tvm.js
@@ -99,15 +99,18 @@ class AwsS3Tvm extends Tvm {
       secretAccessKey: params.awsSecretAccessKey
     })
 
+    const s3Folder = params.owNamespace // allowed chars match
+    const stsTokenName = Tvm._hash(params.owNamespace) // 32 chars max
+
     // 1. generate policy from template
-    const policy = generatePolicy(params.s3Bucket, params.owNamespace)
+    const policy = generatePolicy(params.s3Bucket, s3Folder)
 
     // 2. generate credentials
     const sts = new aws.STS({ apiVersion: '2011-06-15' })
     const stsRes = await wrapAWSCall(sts.getFederationToken({
       DurationSeconds: params.expirationDuration,
       Policy: policy,
-      Name: params.owNamespace
+      Name: stsTokenName
     }).promise())
     if (typeof stsRes.Credentials !== 'object') {
       throw new Error(`sts.getFederationToken didn't return with Credentials, instead: [${JSON.stringify(stsRes)}]`)

--- a/lib/impl/AzureCosmosTvm.js
+++ b/lib/impl/AzureCosmosTvm.js
@@ -12,7 +12,6 @@ governing permissions and limitations under the License.
 
 const { Tvm } = require('../Tvm')
 const cosmos = require('@azure/cosmos')
-const joi = require('@hapi/joi')
 
 /**
  * @class AzureCosmosTvm
@@ -30,8 +29,6 @@ class AzureCosmosTvm extends Tvm {
     this._addToValidationSchema('azureCosmosMasterKey')
     this._addToValidationSchema('azureCosmosDatabaseId')
     this._addToValidationSchema('azureCosmosContainerId')
-    // max chars for cosmos partition key is 100 bytes, make sure owNamespace has max 49 (will be converted to hexa)
-    this._addToValidationSchema('owNamespace', joi.string().min(3).max(49).required())
   }
 
   /**

--- a/lib/types.jsdoc.js
+++ b/lib/types.jsdoc.js
@@ -28,7 +28,7 @@ governing permissions and limitations under the License.
  * @property {string} params.owApiHost - provided by owner, default final
  *
  * @property {string} params.owAuth - user's OpenWhisk Basic Token
- * @property {string} params.owNamespace - user's OpenWhisk Namespace
+ * @property {string} params.owNamespace - user's OpenWhisk Namespace, must be between 3 and 63 chars long
  *
  */
 
@@ -45,7 +45,7 @@ governing permissions and limitations under the License.
  * @property {string} params.owApiHost - provided by owner, default final
  *
  * @property {string} params.owAuth - user's OpenWhisk Basic Token
- * @property {string} params.owNamespace - user's OpenWhisk Namespace
+ * @property {string} params.owNamespace - user's OpenWhisk Namespace, must be between 3 and 63 chars long
  *
  */
 
@@ -61,7 +61,7 @@ governing permissions and limitations under the License.
  * @property {string} params.owApiHost - provided by owner, default final
  *
  * @property {string} params.owAuth - user's OpenWhisk Basic Token
- * @property {string} params.owNamespace - user's OpenWhisk Namespace
+ * @property {string} params.owNamespace - user's OpenWhisk Namespace, must be between 3 and 63 chars long
  *
  */
 

--- a/test/unit/lib/Tvm.test.js
+++ b/test/unit/lib/Tvm.test.js
@@ -44,12 +44,22 @@ describe('processRequest (abstract)', () => {
 
       test('when expirationDuration is missing', async () => global.testParam(tvm, fakeParams, 'expirationDuration', undefined))
       test('when expirationDuration is not parseInt string', async () => global.testParam(tvm, fakeParams, 'expirationDuration', 'hello'))
+
       test('when approvedList is missing', async () => global.testParam(tvm, fakeParams, 'approvedList', undefined))
       test('when approvedList is empty', async () => global.testParam(tvm, fakeParams, 'approvedList', ''))
+
       test('when owApihost is missing', async () => global.testParam(tvm, fakeParams, 'owApihost', undefined))
       test('when owApihost is not a valid uri', async () => global.testParam(tvm, fakeParams, 'owApihost', 'hello'))
+
       test('when owNamespace is missing', async () => global.testParam(tvm, fakeParams, 'owNamespace', undefined))
       test('when owNamespace is empty', async () => global.testParam(tvm, fakeParams, 'owNamespace', ''))
+      test('when owNamespace is bigger than 63 chars', async () => global.testParam(tvm, fakeParams, 'owNamespace', 'a'.repeat(64)))
+      test('when owNamespace is equal to 63 chars', async () => {
+        const ns63chars = 'a'.repeat(63)
+        global.owNsListMock.mockResolvedValue([ns63chars])
+        await global.testParam(tvm, fakeParams, 'owNamespace', ns63chars, 200)
+      })
+      test('when owNamespace is smaller than 3 chars', async () => global.testParam(tvm, fakeParams, 'owNamespace', 'aa'))
 
       test('when authorization header is missing', async () => global.testParam(tvm, fakeParams, '__ow_headers.authorization', undefined, 401))
       test('when authorization header is empty', async () => global.testParam(tvm, fakeParams, '__ow_headers.authorization', '', 401))

--- a/test/unit/lib/impl/AwsS3Tvm.test.js
+++ b/test/unit/lib/impl/AwsS3Tvm.test.js
@@ -28,6 +28,8 @@ fakeParams.s3Bucket = 'fakeBucket'
 fakeParams.awsAccessKeyId = 'fakeAccessKeyId'
 fakeParams.awsSecretAccessKey = 'fakeSecretAccessKey'
 
+const fakeNSHash = 'f3125a324ac7d2024dbbc867fb2e6013' // 32 bit hash of 'fakeNS'
+
 describe('processRequest (AWS)', () => {
   // setup
   /** @type {AwsS3Tvm} */
@@ -76,7 +78,7 @@ describe('processRequest (AWS)', () => {
         DurationSeconds: fakeParams.expirationDuration,
         // policy more checks?
         Policy: expect.stringContaining(fakeParams.owNamespace),
-        Name: fakeParams.owNamespace
+        Name: fakeNSHash
       })
     }
 

--- a/test/unit/lib/impl/AzureCosmosTvm.test.js
+++ b/test/unit/lib/impl/AzureCosmosTvm.test.js
@@ -76,9 +76,6 @@ describe('processRequest (Azure Cosmos)', () => {
   })
 
   describe('param validation', () => {
-    test('when owNamespace is bigger than 49 chars', async () => global.testParam(tvm, fakeParams, 'owNamespace', 'a'.repeat(50)))
-    test('when owNamespace is smaller than 3 chars', async () => global.testParam(tvm, fakeParams, 'owNamespace', 'aa'))
-    test('when owNamespace is missing', async () => global.testParam(tvm, fakeParams, 'owNamespace', undefined))
     test('when azureCosmosAccount is missing', async () => global.testParam(tvm, fakeParams, 'azureCosmosAccount', undefined))
     test('when azureCosmosMasterKey is missing', async () => global.testParam(tvm, fakeParams, 'azureCosmosMasterKey', undefined))
     test('when azureCosmosDatabaseId is missing', async () => global.testParam(tvm, fakeParams, 'azureCosmosDatabaseId', undefined))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- STS token generation fails for > 32 chars namespaces
- evaluate if cosmos tvm needs some changes too 
- needs explicit doc and code for change to max = 63

needs an update  to https://github.com/adobe/aio-lib-state#adobe-io-state-store-limitations-per-user and update to https://github.com/adobe/aio-tvm/blob/ed30c0009f8f9a624bbf74c53dd8e96d737c2045/lib/impl/AzureCosmosTvm.js#L34
<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
