### PR TITLE
Fix for CosmosDB race conditions that resulted in intermittent 500s

### DIFF
--- a/lib/impl/AzureCosmosTvm.js
+++ b/lib/impl/AzureCosmosTvm.js
@@ -52,7 +52,9 @@ class AzureCosmosTvm extends Tvm {
     try {
       user = (await database.user(userId).read()).user
     } catch (e) {
-      if (e.code !== 404) throw e
+      if (e.code !== 404) {
+        throw e
+      }
       user = (await database.users.create({ id: userId })).user
     }
 
@@ -61,12 +63,22 @@ class AzureCosmosTvm extends Tvm {
       // delete to refresh permission (b/c of expiration)
       await user.permission(permissionId).delete()
     } catch (e) {
-      if (e.code !== 404) throw e
+      if (e.code !== 404) {
+        throw e
+      }
     }
-    const resourceToken = (await user.permissions.create({ id: permissionId, permissionMode: cosmos.PermissionMode.All, resource: container.url, resourcePartitionKey: [partitionKey] }, { resourceTokenExpirySeconds: params.expirationDuration })).resource._token
+    const resourceToken = (await user.permissions.create({
+      id: permissionId,
+      permissionMode: cosmos.PermissionMode.All,
+      resource: container.url,
+      resourcePartitionKey: [partitionKey]
+    }, {
+      resourceTokenExpirySeconds: params.expirationDuration
+    })).resource._token
 
     const expiryTime = new Date()
-    expiryTime.setSeconds(expiryTime.getSeconds() + params.expirationDuration)
+    // give 5 minutes less
+    expiryTime.setSeconds(expiryTime.getSeconds() + params.expirationDuration - 300)
 
     return {
       resourceToken,

--- a/lib/impl/AzureCosmosTvm.js
+++ b/lib/impl/AzureCosmosTvm.js
@@ -16,6 +16,8 @@ const logger = require('@adobe/aio-lib-core-logging')('@adobe/aio-tvm')
 
 const RACE_RETRIES = 5
 const RACE_RETRY_INTERVAL = 50 // 50 msec
+const RACE_RETRY_FACTOR = 1.5
+
 /**
  * @class AzureCosmosTvm
  * @classdesc Tvm implementation for Azure Cosmos
@@ -114,6 +116,7 @@ class AzureCosmosTvm extends Tvm {
       logger.info('detected conflict, entering race condition resolution')
 
       // retry 5 times with 50 msec delay
+      let retryTime = RACE_RETRY_INTERVAL
       for (let retryCount = 1; retryCount <= RACE_RETRIES; ++retryCount) {
         try {
           // attempt to retrieve the already created permission
@@ -130,8 +133,9 @@ class AzureCosmosTvm extends Tvm {
             throw e
           }
           // wait a bit before the next try
-          logger.info(`retries left ${RACE_RETRIES - retryCount}, waiting ${RACE_RETRY_INTERVAL} ms..`)
-          await new Promise((resolve, reject) => setTimeout(resolve, RACE_RETRY_INTERVAL))
+          logger.info(`retries left ${RACE_RETRIES - retryCount}, waiting ${retryTime} ms..`)
+          await new Promise((resolve) => setTimeout(resolve, retryTime))
+          retryTime = retryTime * RACE_RETRY_FACTOR
         }
       }
     }

--- a/lib/impl/AzureCosmosTvm.js
+++ b/lib/impl/AzureCosmosTvm.js
@@ -12,7 +12,10 @@ governing permissions and limitations under the License.
 
 const { Tvm } = require('../Tvm')
 const cosmos = require('@azure/cosmos')
+const logger = require('@adobe/aio-lib-core-logging')('@adobe/aio-tvm')
 
+const RACE_RETRIES = 5
+const RACE_RETRY_INTERVAL = 50 // 50 msec
 /**
  * @class AzureCosmosTvm
  * @classdesc Tvm implementation for Azure Cosmos
@@ -46,38 +49,42 @@ class AzureCosmosTvm extends Tvm {
     const database = client.database(params.azureCosmosDatabaseId)
     const container = database.container(params.azureCosmosContainerId)
 
-    // create if not exists
-    let user
+    // set user object
     const userId = 'user-' + partitionKey
-    try {
-      user = (await database.user(userId).read()).user
-    } catch (e) {
-      if (e.code !== 404) {
-        throw e
-      }
-      user = (await database.users.create({ id: userId })).user
-    }
+    const user = database.user(userId)
 
+    // retrieve the permission object
     const permissionId = 'permission-' + partitionKey
+    // NOTE: permissions are created once per partitionKey (= per user).
+    // When we get an existing permission we can set the expiration for the returned token.
+    const resourceTokenExpirySeconds = params.expirationDuration
+    let permissionRes
     try {
-      // delete to refresh permission (b/c of expiration)
-      await user.permission(permissionId).delete()
+      logger.info(`retrieving cosmosDB permission with id: ${permissionId} and expirationDuration: ${resourceTokenExpirySeconds} seconds`)
+      permissionRes = await user.permission(permissionId).read({ resourceTokenExpirySeconds })
+      // An alternative could be to use:
+      // user.permission(permissionId).replace(permissionDefinition, { resourceTokenExpirySeconds })
     } catch (e) {
       if (e.code !== 404) {
         throw e
       }
+      // if the permission doesn't exist we need to 1. create the user + 2. create the permission
+      const permissionDefinition = {
+        id: permissionId,
+        permissionMode: cosmos.PermissionMode.All,
+        resource: container.url,
+        resourcePartitionKey: [partitionKey]
+      }
+      logger.info(`permission with id '${permissionId}' does not exist, creating a new one..`)
+      permissionRes = await this.createUserAndPermission(database, userId, permissionDefinition, resourceTokenExpirySeconds)
     }
-    const resourceToken = (await user.permissions.create({
-      id: permissionId,
-      permissionMode: cosmos.PermissionMode.All,
-      resource: container.url,
-      resourcePartitionKey: [partitionKey]
-    }, {
-      resourceTokenExpirySeconds: params.expirationDuration
-    })).resource._token
 
+    // extract the resource token
+    const resourceToken = permissionRes.resource._token
+
+    // compute the expiration time
     const expiryTime = new Date()
-    // give 5 minutes less
+    // remove 5 minutes for clock skews and permission create race conditions
     expiryTime.setSeconds(expiryTime.getSeconds() + params.expirationDuration - 300)
 
     return {
@@ -87,6 +94,46 @@ class AzureCosmosTvm extends Tvm {
       databaseId: params.azureCosmosDatabaseId,
       containerId: params.azureCosmosContainerId,
       partitionKey
+    }
+  }
+
+  async createUserAndPermission (/** @type {cosmos.Database} */ database, userId, permissionDefinition, resourceTokenExpirySeconds) {
+    try {
+      logger.info(`creating user '${userId}' and permission '${permissionDefinition.id}'..`)
+      await database.users.create({ id: userId })
+      const permissionRes = await database.user(userId).permissions.create(permissionDefinition, { resourceTokenExpirySeconds })
+      return permissionRes
+    } catch (e) {
+      // handle race conditions, some other request in that container or another Adobe I/O Runtime
+      // container might have created the resources already
+      logger.info(`Received status=${e.code} on resource creation`)
+      if (e.code !== 409 && e.code !== 429 && e.code !== 449) {
+        throw e
+      }
+
+      logger.info('detected conflict, entering race condition resolution')
+
+      // retry 5 times with 50 msec delay
+      for (let retryCount = 1; retryCount <= RACE_RETRIES; ++retryCount) {
+        try {
+          // attempt to retrieve the already created permission
+          logger.info(`get permission '${permissionDefinition.id}'`)
+          const permissionRes = await database.user(userId)
+            .permission(permissionDefinition.id)
+            .read({ resourceTokenExpirySeconds })
+          // exit the retry loop and return the permission resource
+          logger.info('successfully resolved race condition')
+          return permissionRes
+        } catch (e) {
+          if (retryCount === RACE_RETRIES) {
+            // last try
+            throw e
+          }
+          // wait a bit before the next try
+          logger.info(`retries left ${RACE_RETRIES - retryCount}, waiting ${RACE_RETRY_INTERVAL} ms..`)
+          await new Promise((resolve, reject) => setTimeout(resolve, RACE_RETRY_INTERVAL))
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@adobe/aio-lib-core-logging": "^1.1.0",
     "@adobe/aio-lib-ims": "4.0.1",
-    "@azure/cosmos": "^3.3.1",
+    "@azure/cosmos": "^3.9.3",
     "@azure/storage-blob": "^10.5.0",
     "@hapi/joi": "^16.1.4",
     "aws-sdk": "^2.539.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Tested manually via:
- Requires to set .env credentials first
- Requires to delete the permission user attached to the namespace first: `await database.user(user-${Buffer.from(owNamespace).toString('hex')).delete()}`

- run 10 concurrent requests to trigger race conditions
```
for ((i=1;i<10;i++)) ;                                    
do nohup node scripts/run azure-cosmos owNamespace=<ns> __ow_headers='{ "authorization": "Basic <Buffer.from(auth).toString('base64')>" }' &
done
```


<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
