### PR TITLE
TVM to throw 500 error for non 4xx errors while OW validation

### DIFF
--- a/lib/Tvm.js
+++ b/lib/Tvm.js
@@ -22,6 +22,12 @@ const LRU = require('lru-cache')
 // the API GW performs some meaningful validation in the future.
 const validApiGWTokensCache = new LRU({ max: 1000, maxAge: 5 * 60 * 1000 })
 
+const KNOWN_4XX_ERRORS = [
+  400,
+  401,
+  403
+]
+
 /**
  * @classdesc Abstract Tvm class
  * @class Tvm
@@ -137,7 +143,7 @@ class Tvm {
       nsList = await ow.namespaces.list() // throws on auth error
     } catch (e) {
       const error = new Error(`Openwhisk Error: ${e.message}`)
-      error.code = e.statusCode.toString()
+      error.code = e.statusCode
       throw error
     }
     // 2. Make sure passed namespace is attached to auth key, this is important
@@ -274,8 +280,8 @@ class Tvm {
         await this._validateNamespaceInApprovedList(params.owNamespace, params.approvedList)
       } catch (e) {
         logger.warn(`unauthorized request: ${e.message}`)
-        if (e.code && !e.code.startsWith('4')) {
-          // return 500 error if its not a 4xx error
+        if (e.code && !KNOWN_4XX_ERRORS.includes(e.code)) {
+          // return 500 error if its not a known 4xx error
           return Tvm._userErrorResponse('server error', 500)
         }
         return Tvm._userErrorResponse('unauthorized request', 403)

--- a/lib/Tvm.js
+++ b/lib/Tvm.js
@@ -136,9 +136,10 @@ class Tvm {
     try {
       nsList = await ow.namespaces.list() // throws on auth error
     } catch (e) {
-      throw new Error(`Openwhisk Error: ${e.message}`)
+      const error = new Error(`Openwhisk Error: ${e.message}`)
+      error.code = e.statusCode.toString()
+      throw error
     }
-
     // 2. Make sure passed namespace is attached to auth key, this is important
     //    against impersonation
     if (!nsList.includes(namespace)) {
@@ -273,6 +274,10 @@ class Tvm {
         await this._validateNamespaceInApprovedList(params.owNamespace, params.approvedList)
       } catch (e) {
         logger.warn(`unauthorized request: ${e.message}`)
+        if (e.code && !e.code.startsWith('4')) {
+          // return 500 error if its not a 4xx error
+          return Tvm._userErrorResponse('server error', 500)
+        }
         return Tvm._userErrorResponse('unauthorized request', 403)
       }
 

--- a/lib/Tvm.js
+++ b/lib/Tvm.js
@@ -149,7 +149,9 @@ class Tvm {
     // 2. Make sure passed namespace is attached to auth key, this is important
     //    against impersonation
     if (!nsList.includes(namespace)) {
-      throw new Error(`Namespace ${namespace} is not part of auth, namespaces registered to auth are [${nsList}]`)
+      const error = Error(`Namespace ${namespace} is not part of auth, namespaces registered to auth are [${nsList}]`)
+      error.code = 403
+      throw error
     }
   }
 
@@ -163,7 +165,9 @@ class Tvm {
   _validateNamespaceInApprovedList (namespace, approvedList) {
     if (approvedList.trim() !== '*' &&
       !approvedList.split(',').map(ns => ns.trim()).includes(namespace)) {
-      throw new Error(`namespace ${namespace} is not approved`)
+      const error = new Error(`namespace ${namespace} is not approved`)
+      error.code = 403
+      throw error
     }
   }
 
@@ -279,11 +283,12 @@ class Tvm {
         await this._validateOWCreds(params.owApihost, params.owNamespace, params.owAuth)
         await this._validateNamespaceInApprovedList(params.owNamespace, params.approvedList)
       } catch (e) {
-        logger.warn(`unauthorized request: ${e.message}`)
-        if (e.code && !KNOWN_4XX_ERRORS.includes(e.code)) {
-          // return 500 error if its not a known 4xx error
+        if (!e.code || !KNOWN_4XX_ERRORS.includes(e.code)) {
+          logger.warn(`server error: ${e.message}`)
+          // return 500 error if its not a known 4xx error or no e.code set
           return Tvm._userErrorResponse('server error', 500)
         }
+        logger.warn(`unauthorized request: ${e.message}`)
         return Tvm._userErrorResponse('unauthorized request', 403)
       }
 

--- a/test/unit/jest.setup.js
+++ b/test/unit/jest.setup.js
@@ -114,6 +114,12 @@ global.expectUnauthorized = (response, log) => {
   expect(global.mockLog.warn).toHaveBeenCalledWith(expect.stringContaining(log))
 }
 
+global.expect500Error = (response, log) => {
+  expect(response.statusCode).toEqual(500)
+  expect(response.body.error).toEqual(expect.stringContaining('server error'))
+  expect(global.mockLog.warn).toHaveBeenCalledWith(expect.stringContaining(log))
+}
+
 global.expectServerError = (response, log) => {
   if (!response.error) {
     throw new Error(`expected 500 error got: ${JSON.stringify(response)}`)

--- a/test/unit/lib/Tvm.test.js
+++ b/test/unit/lib/Tvm.test.js
@@ -172,12 +172,24 @@ describe('processRequest (abstract)', () => {
     })
 
     describe('openwhisk namespace/auth validation', () => {
-      test('when openwhisk.namespaces.list throws an error', async () => {
+      test('when openwhisk.namespaces.list throws a 4xx error', async () => {
         const errorMsg = 'abfjdsjfhbv'
-        global.owNsListMock.mockRejectedValue(new Error(errorMsg))
+        const errorObj = new Error(errorMsg)
+        errorObj.statusCode = 400
+        global.owNsListMock.mockRejectedValue(errorObj)
         const response = await tvm.processRequest(fakeParams)
         global.expectUnauthorized(response, errorMsg)
       })
+
+      test('when openwhisk.namespaces.list throws a non 4xx', async () => {
+        const errorMsg = 'abfjdsjfhbv'
+        const errorObj = new Error(errorMsg)
+        errorObj.statusCode = 503
+        global.owNsListMock.mockRejectedValue(errorObj)
+        const response = await tvm.processRequest(fakeParams)
+        global.expect500Error(response, errorMsg)
+      })
+
       test('when openwhisk.namespaces.list returns with an empty list', async () => {
         global.owNsListMock.mockResolvedValue([])
         const response = await tvm.processRequest(fakeParams)

--- a/test/unit/lib/Tvm.test.js
+++ b/test/unit/lib/Tvm.test.js
@@ -172,10 +172,28 @@ describe('processRequest (abstract)', () => {
     })
 
     describe('openwhisk namespace/auth validation', () => {
-      test('when openwhisk.namespaces.list throws a 4xx error', async () => {
+      test('when openwhisk.namespaces.list throws a 400 error', async () => {
         const errorMsg = 'abfjdsjfhbv'
         const errorObj = new Error(errorMsg)
         errorObj.statusCode = 400
+        global.owNsListMock.mockRejectedValue(errorObj)
+        const response = await tvm.processRequest(fakeParams)
+        global.expectUnauthorized(response, errorMsg)
+      })
+
+      test('when openwhisk.namespaces.list throws a 401 error', async () => {
+        const errorMsg = 'abfjdsjfhbv'
+        const errorObj = new Error(errorMsg)
+        errorObj.statusCode = 401
+        global.owNsListMock.mockRejectedValue(errorObj)
+        const response = await tvm.processRequest(fakeParams)
+        global.expectUnauthorized(response, errorMsg)
+      })
+
+      test('when openwhisk.namespaces.list throws a 403 error', async () => {
+        const errorMsg = 'abfjdsjfhbv'
+        const errorObj = new Error(errorMsg)
+        errorObj.statusCode = 403
         global.owNsListMock.mockRejectedValue(errorObj)
         const response = await tvm.processRequest(fakeParams)
         global.expectUnauthorized(response, errorMsg)


### PR DESCRIPTION
Fixes #41 
When ow creds validation throws a non 4xx error it will not be wrapped into a 403 error. Instead it will be sent as 500 error so that TVM client can retry.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
unit tests, manual test

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
