### PR TITLE
Metrics base url

### DIFF
--- a/lib/Tvm.js
+++ b/lib/Tvm.js
@@ -17,6 +17,7 @@ const crypto = require('crypto')
 const { Ims } = require('@adobe/aio-lib-ims')
 const LRU = require('lru-cache')
 const { setMetricsURL, incBatchCounter } = require('@adobe/aio-metrics-client')
+const METRICS_KEY = 'recordtvmmetrics'
 
 // cache 1000 valid GW tokens for 5 mins
 // note that invalidated tokens will be valid for 5 minutes, this should be readjusted if
@@ -231,16 +232,14 @@ class Tvm {
   /**
    * Send metrics.
    *
-   * @param {object} params request params
+   * @param {object} namespace requested owNamespace
    * @param {string} metricName metric name
    * @param {string} metricLabel metric label
    * @memberof Tvm
    * @private
    */
-  track (params, metricName, metricLabel) {
-    if (params.metricsUrl) {
-      incBatchCounter(metricName, params.owNamespace, metricLabel)
-    }
+  track (namespace, metricName, metricLabel) {
+    incBatchCounter(metricName, namespace, metricLabel)
   }
 
   /* **************************** PRIVATE METHODS TO IMPLEMENT ***************************** */
@@ -270,7 +269,7 @@ class Tvm {
     logger.info('start of request Id - ' + requestId)
 
     if (params.metricsUrl) {
-      setMetricsURL(params.metricsUrl)
+      setMetricsURL(params.metricsUrl + METRICS_KEY)
     }
 
     try {
@@ -280,7 +279,7 @@ class Tvm {
         params.owAuth = Buffer.from(rawToken, 'base64').toString()
       } catch (e) {
         logger.warn(`failed to extract Basic auth token: ${e.message} - request Id - ${requestId}`)
-        this.track(params, 'user_error_count', '403')
+        this.track(params.owNamespace, 'user_error_count', '403')
         return Tvm._userErrorResponse('unauthorized', 403)
       }
 
@@ -288,7 +287,7 @@ class Tvm {
       const res = this._validateRequestParams(params)
       if (res.error) {
         logger.warn(`bad request: ${res.error.message} - request Id - ${requestId}`)
-        this.track(params, 'user_error_count', '400')
+        this.track(params.owNamespace, 'user_error_count', '400')
         return Tvm._userErrorResponse(res.error.message, 400)
       }
       // important - parse expiryDuration to int
@@ -300,7 +299,7 @@ class Tvm {
           await this._validateAdobeIOApiGwServiceToken(params)
         } catch (e) {
           logger.warn(`Adobe I/O API Gateway service token validation failed: ${e.message} - request Id - ${requestId}`)
-          this.track(params, 'user_error_count', '403')
+          this.track(params.owNamespace, 'user_error_count', '403')
           return Tvm._userErrorResponse('unauthorized', 403)
         }
       }
@@ -311,16 +310,16 @@ class Tvm {
       try {
         await this._validateOWCreds(params.owApihost, params.owNamespace, params.owAuth)
         await this._validateNamespaceInApprovedList(params.owNamespace, params.approvedList)
-        this.track(params, 'request_count')
+        this.track(params.owNamespace, 'request_count')
       } catch (e) {
         if (!e.code || !KNOWN_4XX_ERRORS.includes(e.code)) {
           logger.warn(`server error: ${e.message} - request Id - ${requestId}`)
           // return 500 error if its not a known 4xx error or no e.code set
-          this.track(params, 'error_count', '500')
+          this.track(params.owNamespace, 'error_count', '500')
           return Tvm._userErrorResponse('server error', 500)
         }
         logger.warn(`unauthorized request: ${e.message} - request Id - ${requestId}`)
-        this.track(params, 'user_error_count', '403')
+        this.track(params.owNamespace, 'user_error_count', '403')
         return Tvm._userErrorResponse('unauthorized request', 403)
       }
 
@@ -341,7 +340,7 @@ class Tvm {
       }
     } catch (e) {
       logger.error(e)
-      this.track(params, 'error_count', '500')
+      this.track(params.owNamespace, 'error_count', '500')
       // note the error is wrapped in the { error } object, this means that any 500 will
       // appear in the I/O Runtime activation logs as an application error
       return {

--- a/lib/Tvm.js
+++ b/lib/Tvm.js
@@ -14,6 +14,7 @@ const joi = require('joi')
 const openwhisk = require('openwhisk')
 const logger = require('@adobe/aio-lib-core-logging')('@adobe/aio-tvm')
 const crypto = require('crypto')
+const { posix } = require('path')
 const { Ims } = require('@adobe/aio-lib-ims')
 const LRU = require('lru-cache')
 const { setMetricsURL, incBatchCounter } = require('@adobe/aio-metrics-client')
@@ -48,8 +49,7 @@ class Tvm {
       owApihost: joi.string().uri().required(),
       disableAdobeIOApiGwTokenValidation: joi.string().allow('').optional(),
       imsEnv: joi.string().allow('').optional(),
-      // note the validation of metricsUrl happens after its usage
-      metricsUrl: joi.string().allow('').optional().uri(),
+      metricsUrl: joi.string().allow('').optional(),
 
       // those are user openwhisk credentials passed as request params
       owNamespace: joi.string().min(3).max(63).required(),
@@ -269,7 +269,13 @@ class Tvm {
     logger.info('start of request Id - ' + requestId)
 
     if (params.metricsUrl) {
-      setMetricsURL(params.metricsUrl + METRICS_KEY)
+      try {
+        const url = new URL(params.metricsUrl)
+        url.pathname = posix.join(url.pathname, METRICS_KEY)
+        setMetricsURL(url.href)
+      } catch (ex) {
+        console.log('Creating metrics url failed : ', params.metricsUrl)
+      }
     }
 
     try {

--- a/test/unit/lib/Tvm.test.js
+++ b/test/unit/lib/Tvm.test.js
@@ -10,8 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 const { Tvm } = require('../../../lib/Tvm')
-jest.mock('@adobe/aio-metrics-client')
 const metrics = require('@adobe/aio-metrics-client')
+jest.mock('@adobe/aio-metrics-client')
 
 describe('processRequest (abstract)', () => {
   // setup
@@ -281,34 +281,34 @@ describe('processRequest (abstract)', () => {
         expect(response.body.error).toEqual('"metricsUrl" must be a valid uri')
       })
       test('when metrics url is valid', async () => {
-        fakeParams.metricsUrl = 'https://example.com/aio/metrics'
+        fakeParams.metricsUrl = 'https://example.com/aio/metrics/'
         const response = await tvm.processRequest(fakeParams)
         expect(response.statusCode).toEqual(200)
-        expect(metrics.setMetricsURL).toHaveBeenCalledWith('https://example.com/aio/metrics')
+        expect(metrics.setMetricsURL).toHaveBeenCalledWith('https://example.com/aio/metrics/recordtvmmetrics')
         expect(metrics.incBatchCounter).toHaveBeenCalledWith('request_count', fakeParams.owNamespace, undefined)
       })
       test('when metrics url is valid & apigw validation failure', async () => {
         fakeParams.__ow_headers['x-gw-ims-authorization'] = 'bad format'
-        fakeParams.metricsUrl = 'https://example.com/aio/metrics'
+        fakeParams.metricsUrl = 'https://example.com/aio/metrics/'
         const response = await tvm.processRequest(fakeParams)
         expect(response.statusCode).toEqual(403)
-        expect(metrics.setMetricsURL).toHaveBeenCalledWith('https://example.com/aio/metrics')
+        expect(metrics.setMetricsURL).toHaveBeenCalledWith('https://example.com/aio/metrics/recordtvmmetrics')
         expect(metrics.incBatchCounter).toHaveBeenCalledWith('user_error_count', fakeParams.owNamespace, '403')
       })
       test('when metrics url is valid & ow validation failure', async () => {
         fakeParams.owNamespace = 'bad namespace'
-        fakeParams.metricsUrl = 'https://example.com/aio/metrics'
+        fakeParams.metricsUrl = 'https://example.com/aio/metrics/'
         const response = await tvm.processRequest(fakeParams)
         expect(response.statusCode).toEqual(403)
-        expect(metrics.setMetricsURL).toHaveBeenCalledWith('https://example.com/aio/metrics')
+        expect(metrics.setMetricsURL).toHaveBeenCalledWith('https://example.com/aio/metrics/recordtvmmetrics')
         expect(metrics.incBatchCounter).toHaveBeenCalledWith('user_error_count', fakeParams.owNamespace, '403')
       })
       test('when metrics url is valid & server error', async () => {
         tvm._generateCredentials.mockRejectedValue(new Error('fake error'))
-        fakeParams.metricsUrl = 'https://example.com/aio/metrics'
+        fakeParams.metricsUrl = 'https://example.com/aio/metrics/'
         const response = await tvm.processRequest(fakeParams)
         expect(response.error.statusCode).toEqual(500)
-        expect(metrics.setMetricsURL).toHaveBeenCalledWith('https://example.com/aio/metrics')
+        expect(metrics.setMetricsURL).toHaveBeenCalledWith('https://example.com/aio/metrics/recordtvmmetrics')
         expect(metrics.incBatchCounter).toHaveBeenCalledWith('error_count', fakeParams.owNamespace, '500')
       })
     })

--- a/test/unit/lib/Tvm.test.js
+++ b/test/unit/lib/Tvm.test.js
@@ -273,12 +273,13 @@ describe('processRequest (abstract)', () => {
         fakeParams.metricsUrl = ''
         const response = await tvm.processRequest(fakeParams)
         expect(response.statusCode).toEqual(200)
+        expect(metrics.setMetricsURL).not.toHaveBeenCalled()
       })
       test('when metrics url is not a valid uri', async () => {
         fakeParams.metricsUrl = 'aio/metrics'
         const response = await tvm.processRequest(fakeParams)
-        expect(response.statusCode).toEqual(400)
-        expect(response.body.error).toEqual('"metricsUrl" must be a valid uri')
+        expect(response.statusCode).toEqual(200)
+        expect(metrics.setMetricsURL).not.toHaveBeenCalled()
       })
       test('when metrics url is valid', async () => {
         fakeParams.metricsUrl = 'https://example.com/aio/metrics/'

--- a/test/unit/lib/impl/AzureCosmosTvm.test.js
+++ b/test/unit/lib/impl/AzureCosmosTvm.test.js
@@ -13,6 +13,8 @@ const { AzureCosmosTvm } = require('../../../../lib/impl/AzureCosmosTvm')
 
 const cosmos = require('@azure/cosmos')
 jest.mock('@azure/cosmos')
+// because metrics-client uses setTimeout, and some of these tests mock setTimeout
+jest.mock('@adobe/aio-metrics-client')
 
 // find more standard way to mock cosmos?
 const cosmosMocks = {


### PR DESCRIPTION

This changes the call to metrics url, by adding a tvm specific key to the base-url passed as a param

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
