### PR TITLE
Service based deny list to throttle state store usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This might be useful for you if:
 
   # TVM credentials options
   EXPIRATION_DURATION=<token expiration in seconds>
+  EXPIRATION_DURATION_STATE_LIB=<State lib expiration token>
   APPROVED_LIST=<comma separated list of namespaces>
 
   # AWS S3 credentials
@@ -79,6 +80,10 @@ This might be useful for you if:
   # Adobe I/O API Gateway token validation specific
   DISABLE_ADOBE_IO_API_GW_TOKEN_VALIDATION=<optional, set to true if TVM is not deployed behind the Adobe I/O API Gateway>
   IMS_ENV=<not relevant if DISABLE_ADOBE_IO_API_GW_TOKEN_VALIDATION=true, IMS env for validating the Adobe I/O API Gateway token>
+
+  # Optional Params for Monitoring and access control
+  AIO_METRICS_URL=<URL where TVM usage metrics will be sent>
+  AIO_DENY_LIST_URL=<URL from where to fetch service based deny list>
   ```
 
 - Use the `APPROVED_LIST` variable to control which namespace can access the TVM and

--- a/lib/Tvm.js
+++ b/lib/Tvm.js
@@ -17,6 +17,7 @@ const crypto = require('crypto')
 const { posix } = require('path')
 const { Ims } = require('@adobe/aio-lib-ims')
 const LRU = require('lru-cache')
+const fetch = require('node-fetch')
 const { setMetricsURL, incBatchCounter } = require('@adobe/aio-metrics-client')
 const METRICS_KEY = 'recordtvmmetrics'
 
@@ -44,12 +45,13 @@ class Tvm {
   constructor () {
     this._validationSchema = {
       /// deployment params - should not be setable by request - deployed as final
-      expirationDuration: joi.number().integer().min(900).max(18000).required(),
+      expirationDuration: joi.number().integer().min(600).max(18000).required(),
       approvedList: joi.string().required(),
       owApihost: joi.string().uri().required(),
       disableAdobeIOApiGwTokenValidation: joi.string().allow('').optional(),
       imsEnv: joi.string().allow('').optional(),
       metricsUrl: joi.string().allow('').optional(),
+      denyListUrl: joi.string().allow('').optional(),
 
       // those are user openwhisk credentials passed as request params
       owNamespace: joi.string().min(3).max(63).required(),
@@ -92,6 +94,38 @@ class Tvm {
    */
   _addToValidationSchema (key, type) {
     this._validationSchema[key] = type || joi.string().required()
+  }
+
+  /**
+   * Validate namespace against Deny List
+   *
+   * @param {string} denyListUrl deny list URL
+   * @param {string} namespace Namespace to be validated
+   * @param {number} expirationDuration expiry in seconds
+   * @returns {void}
+   * @memberof Tvm
+   * @protected
+   */
+  async _validateServiceBasedDenyList (denyListUrl, namespace, expirationDuration) {
+    if (denyListUrl) {
+      let denyList
+      try {
+        if (Tvm.inMemoryCache.expiry > Date.now()) {
+          denyList = Tvm.inMemoryCache.denyList // use deny list from in-memory cache
+        } else {
+          denyList = await this._fetchDenyList(denyListUrl) // fetch deny list from URL
+          Tvm.inMemoryCache.denyList = denyList
+          Tvm.inMemoryCache.expiry = new Date(Date.now() + (5 * 60000)).valueOf() // refresh list every 5 minutes
+        }
+      } catch (e) {
+        // Ignore and log any errors while checking deny list
+        logger.warn('Error while fetching deny list')
+        logger.error(e)
+      }
+      await this._processDenyList(denyList, namespace, expirationDuration)
+    } else {
+      logger.info('No deny list set')
+    }
   }
 
   /* **************************** PRIVATE HELPERS ***************************** */
@@ -230,6 +264,38 @@ class Tvm {
   }
 
   /**
+   * Fetch Deny List from URL
+   *
+   * @param {string} url deny list url
+   * @returns {object} deny list object
+   * @memberof Tvm
+   * @private
+   */
+  async _fetchDenyList (url) {
+    const resp = await fetch(url)
+    const body = await resp.text()
+    if (resp.ok) {
+      return JSON.parse(body)
+    } else {
+      logger.warn('Error while fetching deny list - ' + body)
+    }
+    return {} // return an empty list
+  }
+
+  /**
+   * Check deny list update timestamp against expiry time
+   *
+   * @param {number} timestamp timestamp when list got updated
+   * @param {number} expiryDurationInSeconds expiry for deny list
+   * @returns {boolean} true/false based on timestamp check
+   * @memberof Tvm
+   * @private
+   */
+  _checkDenyListTimestamp (timestamp, expiryDurationInSeconds) {
+    return ((new Date(timestamp + (expiryDurationInSeconds * 1000))).valueOf() > Date.now())
+  }
+
+  /**
    * Send metrics.
    *
    * @param {object} namespace requested owNamespace
@@ -253,6 +319,19 @@ class Tvm {
    */
   async _generateCredentials (params) {
     throw new Error('not implemented')
+  }
+
+  /**
+   * Process Deny List
+   *
+   * @param {object} denyList deny list object
+   * @param {string} namespace namespace to be validated
+   * @param {number} expiryDuration expiry in seconds
+   * @returns {void}
+   * @memberof Tvm
+   */
+  async _processDenyList (denyList, namespace, expiryDuration) {
+    // Ignore and Do Nothing. Let Individual Services impl define their own processing.
   }
 
   /* **************************** PUBLIC METHOD ***************************** */
@@ -316,6 +395,7 @@ class Tvm {
       try {
         await this._validateOWCreds(params.owApihost, params.owNamespace, params.owAuth)
         await this._validateNamespaceInApprovedList(params.owNamespace, params.approvedList)
+        await this._validateServiceBasedDenyList(params.denyListUrl, params.owNamespace, params.expirationDuration)
         this.track(params.owNamespace, 'request_count')
       } catch (e) {
         if (!e.code || !KNOWN_4XX_ERRORS.includes(e.code)) {
@@ -358,5 +438,7 @@ class Tvm {
     }
   }
 }
+
+Tvm.inMemoryCache = {}
 
 module.exports = { Tvm }

--- a/lib/Tvm.js
+++ b/lib/Tvm.js
@@ -406,7 +406,7 @@ class Tvm {
           } else if (e.code === 429) {
             logger.warn(`throttled request: ${e.message} - request Id - ${requestId}`)
             this.track(params.owNamespace, 'user_error_count', '429')
-            return Tvm._userErrorResponse('throttled request', 429)
+            return Tvm._userErrorResponse(`throttled request - ${e.message}`, 429)
           }
         }
         logger.warn(`server error: ${e.message} - request Id - ${requestId}`)

--- a/lib/impl/AzureCosmosTvm.js
+++ b/lib/impl/AzureCosmosTvm.js
@@ -17,6 +17,7 @@ const logger = require('@adobe/aio-lib-core-logging')('@adobe/aio-tvm')
 const RACE_RETRIES = 5
 const RACE_RETRY_INTERVAL = 50 // 50 msec
 const RACE_RETRY_FACTOR = 1.5
+const SERVICE_NAME = 'statestore'
 
 /**
  * @class AzureCosmosTvm
@@ -96,6 +97,28 @@ class AzureCosmosTvm extends Tvm {
       databaseId: params.azureCosmosDatabaseId,
       containerId: params.azureCosmosContainerId,
       partitionKey
+    }
+  }
+
+  /**
+   * @memberof AzureCosmosTvm
+   * @override
+   * @private
+   */
+  async _processDenyList (denyList, namespace, expiryDuration) {
+    if (denyList) {
+      const cosmosDBDenyList = denyList[SERVICE_NAME]
+      if (cosmosDBDenyList) {
+        // todo validate denylist schema
+        if (this._checkDenyListTimestamp(cosmosDBDenyList.updated, expiryDuration)) {
+          if (cosmosDBDenyList.users && cosmosDBDenyList.users[namespace]) {
+            logger.info(`Namespace ${namespace} denied token generation because usage - ${cosmosDBDenyList.users[namespace]}RUs is above threshold.`)
+            throw new Error(`Usage - ${cosmosDBDenyList.users[namespace]}RUs is above threshold. Wait for sometime and retry.`)
+          }
+        } else {
+          logger.warn('Deny list is expired - ' + cosmosDBDenyList.updated)
+        }
+      }
     }
   }
 

--- a/lib/impl/AzureCosmosTvm.js
+++ b/lib/impl/AzureCosmosTvm.js
@@ -113,7 +113,9 @@ class AzureCosmosTvm extends Tvm {
         if (this._checkDenyListTimestamp(cosmosDBDenyList.updated, expiryDuration)) {
           if (cosmosDBDenyList.users && cosmosDBDenyList.users[namespace]) {
             logger.info(`Namespace ${namespace} denied token generation because usage - ${cosmosDBDenyList.users[namespace]}RUs is above threshold.`)
-            throw new Error(`Usage - ${cosmosDBDenyList.users[namespace]}RUs is above threshold. Wait for sometime and retry.`)
+            const err = new Error(`Usage - ${cosmosDBDenyList.users[namespace]}RUs is above threshold. Wait for sometime and retry.`)
+            err.code = 429
+            throw err
           }
         } else {
           logger.warn('Deny list is expired - ' + cosmosDBDenyList.updated)

--- a/manifest.yml
+++ b/manifest.yml
@@ -75,12 +75,13 @@ packages:
           azureCosmosAccount: $AZURE_COSMOS_ACCOUNT
           azureCosmosDatabaseId: $AZURE_COSMOS_DATABASE_ID
           azureCosmosContainerId: $AZURE_COSMOS_CONTAINER_ID
-          expirationDuration: $EXPIRATION_DURATION
+          expirationDuration: $EXPIRATION_DURATION_STATE_LIB
           owApihost: $AIO_RUNTIME_APIHOST
           approvedList: $APPROVED_LIST
           imsEnv: $IMS_ENV
           disableAdobeIOApiGwTokenValidation: $DISABLE_ADOBE_IO_API_GW_TOKEN_VALIDATION
           metricsUrl: $AIO_METRICS_URL
+          denyListUrl: $AIO_DENY_LIST_URL
         annotations:
           # this is important security wise
           final: true

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "The Adobe I/O token vending machine for used to integrate external cloud services with Adobe I/O Runtime",
   "author": "Adobe Inc.",
   "license": "Apache-2.0",
+  "private": true,
   "engines": {
     "node": ">=14.0.0"
   },

--- a/test/unit/lib/Tvm.test.js
+++ b/test/unit/lib/Tvm.test.js
@@ -25,8 +25,6 @@ describe('processRequest (abstract)', () => {
   let tvm
   let fakeParams
 
-  // fetch.text = jest.fn()
-  // fetch.text.mockResolvedValue(fakeResponse)
   fetch.mockResolvedValue({
     text: fakeResponse,
     ok: true
@@ -355,8 +353,6 @@ describe('processRequest (abstract)', () => {
         const response = await tvm.processRequest(fakeParams)
         expect(response.statusCode).toEqual(200)
         expect(global.mockLog.warn).toHaveBeenCalledTimes(0)
-        // expect(metrics.setMetricsURL).toHaveBeenCalledWith('https://example.com/aio/metrics/recordtvmmetrics')
-        // expect(metrics.incBatchCounter).toHaveBeenCalledWith('request_count', fakeParams.owNamespace, undefined)
       })
 
       test('when deny list url response is valid list', async () => {
@@ -373,8 +369,6 @@ describe('processRequest (abstract)', () => {
         const response = await tvm.processRequest(fakeParams)
         expect(response.statusCode).toEqual(200)
         expect(global.mockLog.warn).toHaveBeenCalledTimes(0)
-        // expect(metrics.setMetricsURL).toHaveBeenCalledWith('https://example.com/aio/metrics/recordtvmmetrics')
-        // expect(metrics.incBatchCounter).toHaveBeenCalledWith('request_count', fakeParams.owNamespace, undefined)
       })
 
       test('when deny list url response is valid list with requested namespace', async () => {
@@ -391,8 +385,6 @@ describe('processRequest (abstract)', () => {
         const response = await tvm.processRequest(fakeParams)
         expect(response.statusCode).toEqual(200)
         expect(global.mockLog.warn).toHaveBeenCalledTimes(0)
-        // expect(metrics.setMetricsURL).toHaveBeenCalledWith('https://example.com/aio/metrics/recordtvmmetrics')
-        // expect(metrics.incBatchCounter).toHaveBeenCalledWith('request_count', fakeParams.owNamespace, undefined)
       })
 
       test('when deny list url fetch errors out', async () => {

--- a/test/unit/lib/Tvm.test.js
+++ b/test/unit/lib/Tvm.test.js
@@ -13,11 +13,24 @@ const { Tvm } = require('../../../lib/Tvm')
 const metrics = require('@adobe/aio-metrics-client')
 jest.mock('@adobe/aio-metrics-client')
 
+const fetch = require('node-fetch')
+jest.mock('node-fetch', () => jest.fn())
+
+const fakeResponse = jest.fn()
+fakeResponse.mockResolvedValue('{}')
+
 describe('processRequest (abstract)', () => {
   // setup
   /** @type {Tvm} */
   let tvm
   let fakeParams
+
+  // fetch.text = jest.fn()
+  // fetch.text.mockResolvedValue(fakeResponse)
+  fetch.mockResolvedValue({
+    text: fakeResponse,
+    ok: true
+  })
   beforeEach(() => {
     tvm = new Tvm()
     fakeParams = JSON.parse(JSON.stringify(global.baseNoErrorParams))
@@ -311,6 +324,75 @@ describe('processRequest (abstract)', () => {
         expect(response.error.statusCode).toEqual(500)
         expect(metrics.setMetricsURL).toHaveBeenCalledWith('https://example.com/aio/metrics/recordtvmmetrics')
         expect(metrics.incBatchCounter).toHaveBeenCalledWith('error_count', fakeParams.owNamespace, '500')
+      })
+    })
+
+    describe('deny list enabled', () => {
+      test('when deny list url is an empty string', async () => {
+        fakeParams.denyListUrl = ''
+        const response = await tvm.processRequest(fakeParams)
+        expect(response.statusCode).toEqual(200)
+      })
+      test('when deny list url response not a valid', async () => {
+        fakeParams.denyListUrl = 'someURL'
+        fetch.mockResolvedValueOnce({
+          text: fakeResponse
+        })
+        const response = await tvm.processRequest(fakeParams)
+        expect(response.statusCode).toEqual(200)
+        expect(global.mockLog.warn).toHaveBeenCalledWith(expect.stringContaining('Error while fetching deny list'))
+      })
+      test('when deny list url response is empty list', async () => {
+        fakeParams.denyListUrl = 'someURL'
+        const response = await tvm.processRequest(fakeParams)
+        expect(response.statusCode).toEqual(200)
+        expect(global.mockLog.warn).toHaveBeenCalledTimes(0)
+        // expect(metrics.setMetricsURL).toHaveBeenCalledWith('https://example.com/aio/metrics/recordtvmmetrics')
+        // expect(metrics.incBatchCounter).toHaveBeenCalledWith('request_count', fakeParams.owNamespace, undefined)
+      })
+
+      test('when deny list url response is valid list', async () => {
+        fakeParams.denyListUrl = 'someURL'
+        fakeResponse.mockResolvedValueOnce(JSON.stringify({
+          statestore: {
+            updated: Date.now(),
+            users: {
+              someNS1: 500,
+              someNS2: 300
+            }
+          }
+        }))
+        const response = await tvm.processRequest(fakeParams)
+        expect(response.statusCode).toEqual(200)
+        expect(global.mockLog.warn).toHaveBeenCalledTimes(0)
+        // expect(metrics.setMetricsURL).toHaveBeenCalledWith('https://example.com/aio/metrics/recordtvmmetrics')
+        // expect(metrics.incBatchCounter).toHaveBeenCalledWith('request_count', fakeParams.owNamespace, undefined)
+      })
+
+      test('when deny list url response is valid list with requested namespace', async () => {
+        fakeParams.denyListUrl = 'someURL'
+        fakeResponse.mockResolvedValueOnce(JSON.stringify({
+          statestore: {
+            updated: Date.now(),
+            users: {
+              fakeNS: 500,
+              someNS: 300
+            }
+          }
+        }))
+        const response = await tvm.processRequest(fakeParams)
+        expect(response.statusCode).toEqual(200)
+        expect(global.mockLog.warn).toHaveBeenCalledTimes(0)
+        // expect(metrics.setMetricsURL).toHaveBeenCalledWith('https://example.com/aio/metrics/recordtvmmetrics')
+        // expect(metrics.incBatchCounter).toHaveBeenCalledWith('request_count', fakeParams.owNamespace, undefined)
+      })
+
+      test('when deny list url fetch errors out', async () => {
+        fakeParams.denyListUrl = 'someURL'
+        fakeResponse.mockRejectedValueOnce(new Error('network error'))
+        const response = await tvm.processRequest(fakeParams)
+        expect(response.statusCode).toEqual(200)
+        expect(global.mockLog.warn).toHaveBeenCalledTimes(0)
       })
     })
   })

--- a/test/unit/lib/impl/AzureCosmosTvm.test.js
+++ b/test/unit/lib/impl/AzureCosmosTvm.test.js
@@ -23,7 +23,6 @@ jest.mock('node-fetch', () => jest.fn())
 const fakeResponse = jest.fn()
 const fetchDenyListSpy = jest.spyOn(Tvm.prototype, '_fetchDenyList')
 const processDenyListSpy = jest.spyOn(Tvm.prototype, '_processDenyList')
-// fakeResponse.mockResolvedValue('{}')
 
 // find more standard way to mock cosmos?
 const cosmosMocks = {
@@ -298,7 +297,6 @@ describe('processRequest (Azure Cosmos)', () => {
     test('when deny list url response is valid but list is expired', async () => {
       const expiredDate = new Date(Date.now() - fakeParams.expirationDuration * 1000).valueOf()
       fakeParams.denyListUrl = 'someURL'
-      // fakeResponse.mockClear()
       fakeResponse.mockResolvedValueOnce(JSON.stringify({
         statestore: {
           updated: expiredDate,


### PR DESCRIPTION
Stopgap fix to throttle State Store DB usage

## Description

- Add a service based deny list validation for TVM 
- TVM will fetch the deny list from denyListUrl ( if its set  in params). Each service impl will process deny list in its own way to provide enough flexibility.
- Deny list will be cached in memory to improve performance. 
- TVM will make sure not to use any deny list beyond its expiry. 
- Changed Cosmos DB token expiration to 10 mins. This will enable to throttle any excessive usage of State Store for a given Namespace


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manual Testing against TVM deployment
unit tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
